### PR TITLE
Adding String as valid type for queryId

### DIFF
--- a/druid/druid.d.ts
+++ b/druid/druid.d.ts
@@ -31,7 +31,7 @@ declare module Druid {
     interface Context {
         timeout?: number;
         priority?: number;
-        queryId?: number;
+        queryId?: number | string;
         useCache?: FancyBoolean;
         populateCache?: FancyBoolean;
         bySegment?: FancyBoolean;


### PR DESCRIPTION
A string is absolutely a valid type to put here